### PR TITLE
PLAT-1960 script to patch app in namespaces

### DIFF
--- a/mage/releaser.go
+++ b/mage/releaser.go
@@ -92,6 +92,14 @@ func CreateApplicationMirrorRelease(_ context.Context, application string, relea
 	return MustGetInstance().CreateApplicationMirrorRelease(application, release)
 }
 
+// PatchApplicationInNamespaces creates per-namespace and per-cluster kustomization patches for an application
+//
+// If locatorApplication is not empty, all namespaces that have locatorApplication as the kustomization resource
+// will be patched. If it's empty, all namespaces that have applicationName will be patched.
+func PatchApplicationInNamespaces(_ context.Context, applicationName, locatorApplication string) error {
+	return MustGetInstance().PatchApplicationInNamespaces(applicationName, locatorApplication)
+}
+
 // ListApplications will list all applications
 func ListApplications(_ context.Context) error {
 	apps, err := MustGetInstance().ListApplications()

--- a/releaser/api.go
+++ b/releaser/api.go
@@ -408,7 +408,7 @@ func (f *FromCommandLine) patchApplicationInNamespace(cluster, namespace, applic
 }
 
 func (f *FromCommandLine) guessApplicationRelease(cluster, namespace, application string) (string, error) {
-	staging := strings.Index(cluster, "staging") != -1
+	staging := strings.Contains(cluster, "staging")
 	releases, err := f.ListReleases(application)
 	if err != nil {
 		return "", err
@@ -420,7 +420,7 @@ func (f *FromCommandLine) guessApplicationRelease(cluster, namespace, applicatio
 		return releases[0], nil
 	}
 	for _, r := range releases {
-		if strings.Index(r, "prod") != -1 {
+		if strings.Contains(r, "prod") {
 			return r, nil
 		}
 	}


### PR DESCRIPTION
Added a new mage command `patchApplicationInNamespace`, which finds all
namespaces that needs patched by looking up if they use `locatorApplication`.
It adds the application as the namespaces' kustomization resources and creates
per-cluster and per-namespace patches for the application.